### PR TITLE
Experimental area-weighted regridding using AGG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.pyc
+
+build/
+dist/
+
+lib/mo_lab/_agg.cpp
+lib/mo_lab/_agg.so

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/COPYING.LESSER
+++ b/COPYING.LESSER
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/lib/agg_regrid/__init__.py
+++ b/lib/agg_regrid/__init__.py
@@ -1,0 +1,420 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of iris-extras.
+#
+# iris-extras is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# iris-extras is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with iris-extras.  If not, see <http://www.gnu.org/licenses/>.
+"""A package for experimental regridding functionality."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, xrange, zip)
+
+import copy
+from math import ceil, floor
+import operator
+
+import numpy as np
+import numpy.ma as ma
+
+import iris
+from iris.analysis._interpolation import snapshot_grid, get_xy_dim_coords
+
+from ._agg import raster as agg_raster
+
+
+__version__ = '0.1.0-dev'
+
+
+class AreaWeighted(object):
+    """
+    The Anti-Grain Geometry (AGG) regridding scheme for performing
+    area-weighted conservative regridding.
+
+    """
+    def __repr__(self):
+        return '{}()'.format(self.__class__.__name__)
+
+    def regridder(self, src_grid, tgt_grid):
+        """
+        Creates an Anti-Grain Geometry (AGG) regridder to perform
+        area-weighted conservative regridding between the source
+        grid and the target grid.
+
+        Args:
+
+        * src_grid:
+            The :class:`~iris.cube.Cube` defining the source grid.
+        * tgt_grid:
+            The :class:`~iris.cube.Cube` defining the target grid.
+
+        Returns:
+            A callable with the interface:
+
+                `callable(cube)`
+
+            where `cube` is a :class:`iris.cube.Cube` with the same grid
+            as the source grid defined for regridding to the target grid.
+
+        """
+        return _AreaWeightedRegridder(src_grid, tgt_grid)
+
+
+class _AreaWeightedRegridder(object):
+    """
+    This class provides support for performing area-weighted regridding.
+
+    """
+    def __init__(self, src_grid_cube, tgt_grid_cube):
+        """
+        Creates a area-weighted regridder which uses an Anti-Grain
+        Geometry (AGG) backend to rasterise the conversion between the source
+        and target grids.
+
+        Args:
+
+        * src_grid_cube:
+            The :class:`~iris.cube.Cube` providing the source grid.
+        * tgt_grid_cube:
+            The :class:`~iris.cube.Cube` providing the target grid.
+
+        """
+        if not isinstance(src_grid_cube, iris.cube.Cube):
+            raise TypeError('This source grid must be a cube.')
+        if not isinstance(tgt_grid_cube, iris.cube.Cube):
+            raise TypeError('The target grid must be a cube.')
+
+        # Snapshot the state of the grid cubes to ensure that the regridder
+        # is impervious to external changes to the original cubes.
+        self._src_grid = snapshot_grid(src_grid_cube)
+        self._gx, self._gy = snapshot_grid(tgt_grid_cube)
+
+        # Check the grid cube coordinate system.
+        if self._gx.coord_system is None:
+            msg = 'The grid cube requires a native coordinate system.'
+            raise ValueError(msg)
+
+        # Cache the grid bounds converted to the source crs.
+        self._gx_bounds = None
+        self._gy_bounds = None
+
+        # Cache the source contiguous bounds.
+        self._sx_bounds = None
+        self._sy_bounds = None
+
+    def __call__(self, src_cube):
+        """
+        Regrid the provided :class:`~iris.cube.Cube` on to the target grid
+        of this :class:`AreaWeightedRegridder`.
+
+        The supplied :class:`~iris.cube.Cube` must be defined with the same
+        grid as the source grid used to create this
+        :class:`AreaWeightedRegridder`.
+
+        Args:
+
+        * src_cube:
+            A :class:`~iris.cube.Cube` to be regridded.
+
+        Returns:
+            A :class:`~iris.cube.Cube` defined with the horizontal dimensions
+            of the target and the other dimensions from the supplied source
+            :class:`~iris.cube.Cube`. The data values of the supplied source
+            :class:`~iris.cube.Cube` will be converted to values on the new
+            grid using conservative area-weighted regridding.
+
+        """
+        # Sanity check the supplied source cube.
+        if not isinstance(src_cube, iris.cube.Cube):
+            raise TypeError('The source must be a cube.')
+
+        # Get the source cube x and y coordinates.
+        sx, sy = get_xy_dim_coords(src_cube)
+        if (sx, sy) != self._src_grid:
+            emsg = 'The source cube is not defined on the same source grid ' \
+                'as this regridder.'
+            raise ValueError(emsg)
+        if sx.coord_system is None:
+            msg = 'The source cube requires a native coordinate system.'
+            raise ValueError(msg)
+
+        # Convert the contiguous bounds of the grid to the source crs.
+        gxx, gyy = np.meshgrid(self._gx.contiguous_bounds(),
+                               self._gy.contiguous_bounds())
+
+        # Now calculate and cache the grid bounds in the source crs.
+        if self._gx_bounds is None or self._gy_bounds is None:
+            if sx.coord_system == self._gx.coord_system:
+                self._gx_bounds, self._gy_bounds = gxx, gyy
+            else:
+                from_crs = self._gx.coord_system.as_cartopy_crs()
+                to_crs = sx.coord_system.as_cartopy_crs()
+                xyz = to_crs.transform_points(from_crs, gxx, gyy)
+                self._gx_bounds, self._gy_bounds = xyz[..., 0], xyz[..., 1]
+
+        # Calculate and cache the source contiguous bounds.
+        if self._sx_bounds is None or self._sy_bounds is None:
+            self._sx_bounds = sx.contiguous_bounds()
+            self._sy_bounds = sy.contiguous_bounds()
+
+        sx_dim = src_cube.coord_dims(sx)[0]
+        sy_dim = src_cube.coord_dims(sy)[0]
+
+        # Perform the regrid.
+        result = agg(src_cube.data, sx.points, self._sx_bounds,
+                     sy.points, self._sy_bounds, sx_dim, sy_dim,
+                     self._gx_bounds, self._gy_bounds)
+
+        #
+        # XXX: Need to deal the factories when constructing result cube.
+        #
+        result_cube = iris.cube.Cube(result)
+        result_cube.metadata = copy.deepcopy(src_cube.metadata)
+        coord_mapping = {}
+
+        def copy_coords(coords, add_coord):
+            for coord in coords:
+                dims = src_cube.coord_dims(coord)
+                if coord is sx:
+                    coord = self._gx
+                elif coord is sy:
+                    coord = self._gy
+                elif sx_dim in dims or sy_dim in dims:
+                    continue
+                result_coord = coord.copy()
+                add_coord(result_coord, dims)
+                coord_mapping[id(coord)] = result_coord
+
+        copy_coords(src_cube.dim_coords, result_cube.add_dim_coord)
+        copy_coords(src_cube.aux_coords, result_cube.add_aux_coord)
+
+        return result_cube
+
+
+def agg(data, sx_points, sx_bounds, sy_points, sy_bounds,
+        sx_dim, sy_dim, gx_bounds, gy_bounds):
+    """
+    Perform a area-weighted regrid of the data using an Anti-Grain
+    Geometry (AGG) backend to rasterise the conversion between the source
+    and target grids.
+
+    Args:
+
+    * data:
+        The source grid data, which must be at least 2d, that requires
+        to be regridded to the target grid.
+    * sx_points:
+        The source grid x-coordinate points, which must be 1d, monotonic
+        and regular.
+    * sx_bounds:
+        The source grid x-coordinate contiguous bounds, which must be 1d,
+        monotonic and regular.
+    * sy_points:
+        The source grid y-coordinate points, which must be 1d, monotonic
+        and regular.
+    * sy_bounds:
+        The source grid y-coordinate contiguous bounds, which must be 1d,
+        monotonic and regular.
+    * sx_dim:
+        The data dimension of the x-coordinate.
+    * sy_dim:
+        The data dimensoin of the y-coordinate.
+    * gx_bounds:
+        The target grid x-coordinate contiguous bounds, which must be 2d.
+        The dimensionality of the target grid is assumed to be in (y, x) order.
+    * gy_bounds:
+        The target grid y-coordinate contiguous bounds, which must be 2d.
+        The dimensionality of the target grid is assumed to be in (y, x) order.
+
+    Returns:
+        The data with same horizontal dimensionality as the target grid. The
+        data values are converted to the new grid using conservative
+        area-weighted regridding.
+
+    """
+    #
+    # Sanity check the arguments ...
+    #
+    if sx_points.ndim != 1:
+        emsg = 'Expected 1d src x-coordinate points, got {}d.'
+        raise ValueError(emsg.format(sx_points.ndim))
+
+    if sy_points.ndim != 1:
+        emsg = 'Expected 1d src y-coordinate points, got {}d.'
+        raise ValueError(emsg.format(sy_points.ndim))
+
+    if sx_bounds.ndim != 1:
+        emsg = 'Expected 1d contiguous src x-coordinate bounds, got {}d.'
+        raise ValueError(emsg.format(sx_bounds.ndim))
+
+    if sy_bounds.ndim != 1:
+        emsg = 'Expected 1d contiguous src y-coordinate bounds, got {}d.'
+        raise ValueError(emsg.format(sy_bounds.ndim))
+
+    if sx_bounds.size != sx_points.size + 1:
+        emsg = 'Invalid number of src x-coordinate bounds, got {} expected {}.'
+        raise ValueError(emsg.format(sx_bounds.size, sx_points.size + 1))
+
+    if sy_bounds.size != sy_points.size + 1:
+        emsg = 'Invalid number of src y-coordinate bounds, got {} expected {}.'
+        raise ValueError(emsg.format(sy_bounds.size, sy_points.size + 1))
+
+    # Determine the source data dimensionality ...
+    ndim = data.ndim
+    dims = list(range(ndim))
+
+    if data.ndim < 2:
+        emsg = 'Expected at least 2d src data, got {}d.'
+        raise ValueError(emsg.format(data.ndim))
+
+    # Account for negative indexing ...
+    dim = sx_dim
+    if sx_dim < 0:
+        sx_dim = ndim + sx_dim
+
+    if sx_dim not in dims:
+        emsg = 'Invalid src x-coordinate dimension, got {} expected ' \
+            'within range {}-{}.'
+        raise ValueError(emsg.format(dim, dims[0], dims[-1]))
+
+    # Account for negative indexing ...
+    dim = sy_dim
+    if sy_dim < 0:
+        sy_dim = ndim + sy_dim
+
+    if sy_dim not in dims:
+        emsg = 'Invalid src y-coordinate dimension, got {} expected ' \
+            'within range {}-{}.'
+        raise ValueError(emsg.format(dim, dims[0], dims[-1]))
+
+    # Determine the source data shape ...
+    shape = data.shape
+
+    if shape[sx_dim] != sx_points.size:
+        emsg = 'The src x-coordinate points {} do not align with src data {}' \
+            ' over dimension {}.'
+        raise ValueError(emsg.format(sx_points.shape, shape, sx_dim))
+
+    if shape[sy_dim] != sy_points.size:
+        emsg = 'The src y-coordinate points {} do not align with src data {}' \
+            ' over dimension {}.'
+        raise ValueError(emsg.format(sy_points.shape, shape, sy_dim))
+
+    if gx_bounds.ndim != 2:
+        emsg = 'Expected 2d contiguous grid x-coordinate bounds, got {}d.'
+        raise ValueError(emsg.format(gx_bounds.ndim))
+
+    if gy_bounds.ndim != 2:
+        emsg = 'Expected 2d contiguous grid y-coordinate bounds, got {}d.'
+        raise ValueError(emsg.format(gy_bounds.ndim))
+
+    if gx_bounds.shape != gy_bounds.shape:
+        emsg = 'Misaligned grid x-coordinate bounds {} and ' \
+            'y-coordinate bounds {}.'
+        raise ValueError(emsg.format(gx_bounds.shape, gy_bounds.shape))
+
+    # Ensure the grid bounds have the correct dtype ...
+    gx_bounds = np.asarray(gx_bounds, dtype=np.float64)
+    gy_bounds = np.asarray(gy_bounds, dtype=np.float64)
+
+    #
+    # XXX: Makes gross assumption that all coordinates are increasing.
+    # Need to deal with this properly in a generic way.
+    #
+
+    def start_and_delta(points, bounds, kind):
+        # Constrain to regular points only.
+        delta = np.diff(points)
+        mean_delta = np.mean(delta)
+        rtol = 0.002
+        try:
+            atol = mean_delta * rtol
+            np.testing.assert_allclose(delta, mean_delta, atol=atol)
+        except AssertionError as e:
+            emsg = 'Expected src {}-coordinate points to be regular{}'
+            raise ValueError(emsg.format(kind, e.message))
+        return bounds.min(), mean_delta
+
+    sx0, sdx = start_and_delta(sx_points, sx_bounds, 'x')
+    sy0, sdy = start_and_delta(sy_points, sy_bounds, 'y')
+
+    #
+    # Deal with generic source shape ...
+    #
+    snx, sny = sx_points.size, sy_points.size
+    dr = [sy_dim, sx_dim]
+    do = ndim - len(dr)
+    ds = sorted(dims, key=lambda d: d in dr)
+    dmap = {d: dr.index(d) + do if d in dr else ds.index(d) for d in dims}
+    regrid_order, _ = zip(*sorted(dmap.items(), key=operator.itemgetter(1)))
+    _, result_order = zip(*sorted(dmap.items(), key=operator.itemgetter(0)))
+
+    if regrid_order != tuple(dims):
+        data = np.transpose(data, regrid_order)
+
+    # Reshape the source data into (-1, y, x)
+    regrid_shape = data.shape
+    data = data.reshape((-1,) + regrid_shape[-2:])
+
+    #
+    # Deal with generic grid shape ...
+    #
+    gnx, gny = gx_bounds.shape[1] - 1, gx_bounds.shape[0] - 1
+    result = ma.empty((data.shape[0], gny, gnx))
+    result_shape = list(regrid_shape)
+    result_shape[-2:] = gny, gnx
+    result_shape = tuple(result_shape)
+    result.mask = True
+
+    #
+    # XXX: Cythonise this ...
+    #
+    dims = (1, 2)
+    for yi in xrange(gny):
+        for xi in xrange(gnx):
+            yi_stop = yi + 2
+            xi_stop = xi + 2
+            # Get the bounding box of the grid cell in source coordinates.
+            cell_x = gx_bounds[yi:yi_stop, xi:xi_stop]
+            cell_y = gy_bounds[yi:yi_stop, xi:xi_stop]
+            # Convert to fractional source indices.
+            cell_xi = (cell_x - sx0) / sdx
+            cell_yi = (cell_y - sy0) / sdy
+            xi_min, xi_max = min(*cell_xi.flat), max(*cell_xi.flat)
+            yi_min, yi_max = min(*cell_yi.flat), max(*cell_yi.flat)
+            if xi_min < 0 or yi_min < 0 or xi_max > snx or yi_max > sny:
+                # At least one vertex of the grid cell is out of bounds.
+                continue
+            # Snap fractional cell indices outwards to actual source indices.
+            xi_min = int(floor(xi_min))
+            xi_max = int(ceil(xi_max))
+            yi_min = int(floor(yi_min))
+            yi_max = int(ceil(yi_max))
+            # Calculate the weights for the source region
+            # overlapped by this grid cell.
+            cell_xi -= xi_min
+            cell_yi -= yi_min
+            weights = np.zeros((yi_max - yi_min, xi_max - xi_min),
+                               dtype=np.uint8)
+            agg_raster(weights, cell_xi, cell_yi)
+            weights = weights / 255
+            # Now calculate the weighted result for this grid cell.
+            tmp = data[:, yi_min:yi_max, xi_min:xi_max]
+            result[:, yi, xi] = (tmp * weights).sum(axis=dims) / weights.sum()
+
+    if result.shape != result_shape:
+        result = result.reshape(result_shape)
+
+    if result_order != tuple(dims):
+        result = np.transpose(result, result_order)
+
+    return result

--- a/lib/agg_regrid/_agg.pyx
+++ b/lib/agg_regrid/_agg.pyx
@@ -1,0 +1,52 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of iris-extras.
+#
+# iris-extras is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# iris-extras is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with iris-extras.  If not, see <http://www.gnu.org/licenses/>.
+"""Anti-Grain Geometry (AGG) raster weight functionality."""
+
+cimport numpy as np
+
+
+cdef extern from "_agg_raster.h":
+    void _raster(np.uint8_t *weights, const double *xi, const double *yi,
+                 int nx, int ny)
+
+
+def raster(np.ndarray[np.uint8_t, ndim=2] weights,
+           np.ndarray[np.float64_t, ndim=2] xi,
+           np.ndarray[np.float64_t, ndim=2] yi):
+    """
+    Utilises the sub-pixel accuracy and anti-aliasing capability of the
+    Anti-Grain Geometry (AGG) to calculate rasterised weights.
+
+    Renders a single grey-scale (0-255) target cell in the source grid buffer.
+    Draws the 4 sided target cell as a straight edged polygon, in a clock-wise
+    direction from the top-left-hand-corner, to the top-right-hand-corner, to
+    the bottom-right-hand-corner to the bottom-left-hand-corner. 
+
+    The origin of the buffer is the top-left-hand-corner.
+
+    Args:
+
+    * weights:
+        The 2d weights buffer is updated in-place.
+    * xi:
+        The fractional x-coordinates of the target cell corners.
+    * yi:
+        The fractional y-coordinates of the target cell corners.
+
+    """
+    _raster(<np.uint8_t *>weights.data, <const double *>xi.data,
+            <const double *>yi.data, weights.shape[1], weights.shape[0])

--- a/lib/agg_regrid/_agg_raster.cpp
+++ b/lib/agg_regrid/_agg_raster.cpp
@@ -1,0 +1,56 @@
+/*
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of iris-extras.
+#
+# iris-extras is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# iris-extras is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with iris-extras.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <string.h>
+
+#include <agg_basics.h>
+#include <agg_pixfmt_gray.h>
+#include <agg_rasterizer_scanline_aa.h>
+#include <agg_renderer_base.h>
+#include <agg_renderer_scanline.h>
+#include <agg_rendering_buffer.h>
+//#include <agg_scanline_p.h>
+#include <agg_scanline_u.h>
+
+#include <_agg_raster.h>
+
+
+void _raster(uint8_t *weights, const double *xi, const double *yi,
+             int nx, int ny)
+{
+    typedef agg::renderer_base<agg::pixfmt_gray8> ren_base;
+
+    agg::rendering_buffer rbuf(weights, nx, ny, nx);
+    agg::pixfmt_gray8 pixf(rbuf);
+    ren_base ren(pixf);
+    //agg::scanline_p8 sl;
+    agg::scanline_u8 sl;
+
+    //ren.clear(agg::gray8(255));
+
+    agg::rasterizer_scanline_aa<> ras;
+
+    ras.reset();
+    ras.move_to_d(xi[0], yi[0]);
+    ras.line_to_d(xi[1], yi[1]);
+    ras.line_to_d(xi[3], yi[3]);
+    ras.line_to_d(xi[2], yi[2]);
+
+    agg::render_scanlines_aa_solid(ras, sl, ren, agg::gray8(255));
+}

--- a/lib/agg_regrid/_agg_raster.h
+++ b/lib/agg_regrid/_agg_raster.h
@@ -1,0 +1,29 @@
+/*
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of iris-extras.
+#
+# iris-extras is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# iris-extras is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with iris-extras.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _AGG_RASTER_H
+#define _AGG_RASTER_H
+
+#include <stdint.h>
+
+
+void _raster(uint8_t *weights, const double *xi, const double *yi,
+             int nx, int ny);
+
+#endif

--- a/lib/agg_regrid/tests/__init__.py
+++ b/lib/agg_regrid/tests/__init__.py
@@ -1,0 +1,20 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of iris-extras.
+#
+# iris-extras is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# iris-extras is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with iris-extras.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for agg_regrid."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, xrange, zip)

--- a/lib/agg_regrid/tests/test_agg.py
+++ b/lib/agg_regrid/tests/test_agg.py
@@ -1,0 +1,365 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of iris-extras.
+#
+# iris-extras is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# iris-extras is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with iris-extras.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for the `agg_regrid.agg` function."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, xrange, zip)
+
+import numpy as np
+import numpy.ma as ma
+from numpy.testing import assert_array_equal
+import unittest
+
+from agg_regrid import agg
+
+
+class TestDimensionality(unittest.TestCase):
+    def setUp(self):
+        nz, ny, nx = shape = 5, 10, 20
+        self.data = np.empty(shape)
+        self.sx_points = np.arange(nx)
+        self.sx_bounds = np.arange(nx + 1)
+        self.sy_points = np.arange(ny)
+        self.sy_bounds = np.arange(ny + 1)
+        self.sy_dim, self.sx_dim = 1, 2
+        self.gx_bounds = np.empty((5, 5))
+        self.gy_bounds = np.empty((5, 5))
+
+    def test_src_x_points(self):
+        sx_points = self.sx_points.reshape(1, -1)
+        emsg = 'Expected 1d src x-coordinate points'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(self.data, sx_points, self.sx_bounds,
+                self.sy_points, self.sy_bounds,
+                self.sx_dim, self.sy_dim,
+                self.gx_bounds, self.gy_bounds)
+
+    def test_src_y_points(self):
+        sy_points = self.sy_points.reshape(1, -1)
+        emsg = 'Expected 1d src y-coordinate points'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(self.data, self.sx_points, self.sx_bounds,
+                sy_points, self.sy_bounds,
+                self.sx_dim, self.sy_dim,
+                self.gx_bounds, self.gy_bounds)
+
+    def test_src_x_bounds(self):
+        sx_bounds = self.sx_bounds.reshape(1, -1)
+        emsg = 'Expected 1d contiguous src x-coordinate bounds'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(self.data, self.sx_points, sx_bounds,
+                self.sy_points, self.sy_bounds,
+                self.sx_dim, self.sy_dim,
+                self.gx_bounds, self.gy_bounds)
+
+    def test_src_y_bounds(self):
+        sy_bounds = self.sy_bounds.reshape(1, -1)
+        emsg = 'Expected 1d contiguous src y-coordinate bounds'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(self.data, self.sx_points, self.sx_bounds,
+                self.sy_points, sy_bounds,
+                self.sx_dim, self.sy_dim,
+                self.gx_bounds, self.gy_bounds)
+
+    def test_data(self):
+        data = self.data.flatten()
+        emsg = 'Expected at least 2d src data'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(data, self.sx_points, self.sx_bounds,
+                self.sy_points, self.sy_bounds,
+                self.sx_dim, self.sy_dim,
+                self.gx_bounds, self.gy_bounds)
+
+    def test_src_x_dim(self):
+        # Positive index beyond last dimension.
+        sx_dim = self.data.ndim
+        emsg = 'Invalid src x-coordinate dimension'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(self.data, self.sx_points, self.sx_bounds,
+                self.sy_points, self.sy_bounds,
+                sx_dim, self.sy_dim,
+                self.gx_bounds, self.gy_bounds)
+
+    def test_src_y_dim(self):
+        # Negative index before first dimension.
+        sy_dim = -(self.data.ndim + 1)
+        emsg = 'Invalid src y-coordinate dimension'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(self.data, self.sx_points, self.sx_bounds,
+                self.sy_points, self.sy_bounds,
+                self.sx_dim, sy_dim,
+                self.gx_bounds, self.gy_bounds)
+
+    def test_grid_x_bounds(self):
+        gx_bounds = self.gx_bounds.flatten()
+        emsg = 'Expected 2d contiguous grid x-coordinate bounds'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(self.data, self.sx_points, self.sx_bounds,
+                self.sy_points, self.sy_bounds,
+                self.sx_dim, self.sy_dim,
+                gx_bounds, self.gy_bounds)
+
+    def test_grid_y_bounds(self):
+        gy_bounds = self.gy_bounds.flatten()
+        emsg = 'Expected 2d contiguous grid y-coordinate bounds'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(self.data, self.sx_points, self.sx_bounds,
+                self.sy_points, self.sy_bounds,
+                self.sx_dim, self.sy_dim,
+                self.gx_bounds, gy_bounds)
+
+
+class TestShape(unittest.TestCase):
+    def setUp(self):
+        nz, self.ny, self.nx = self.shape = 5, 10, 20
+        self.data = np.empty(self.shape)
+        self.sx_points = np.arange(self.nx)
+        self.sx_bounds = np.arange(self.nx + 1)
+        self.sy_points = np.arange(self.ny)
+        self.sy_bounds = np.arange(self.ny + 1)
+        self.sy_dim, self.sx_dim = 1, 2
+        self.gx_bounds = np.empty((5, 5))
+        self.gy_bounds = np.empty((5, 5))
+
+    def test_src_x_points_and_bounds(self):
+        sx_points = np.arange(self.nx - 1)
+        emsg = 'Invalid number of src x-coordinate bounds'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(self.data, sx_points, self.sx_bounds,
+                self.sy_points, self.sy_bounds,
+                self.sx_dim, self.sy_dim,
+                self.gx_bounds, self.gy_bounds)
+
+    def test_src_y_points_and_bounds(self):
+        sy_points = np.arange(self.ny - 1)
+        emsg = 'Invalid number of src y-coordinate bounds'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(self.data, self.sx_points, self.sx_bounds,
+                sy_points, self.sy_bounds,
+                self.sx_dim, self.sy_dim,
+                self.gx_bounds, self.gy_bounds)
+
+    def test_src_x_points_and_data(self):
+        shape = list(self.shape)
+        shape[self.sx_dim] = self.nx + 1
+        data = np.empty(shape)
+        emsg = 'src x-coordinate points .* do not align'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(data, self.sx_points, self.sx_bounds,
+                self.sy_points, self.sy_bounds,
+                self.sx_dim, self.sy_dim,
+                self.gx_bounds, self.gy_bounds)
+
+    def test_src_y_points_and_data(self):
+        shape = list(self.shape)
+        shape[self.sy_dim] = self.ny - 1
+        data = np.empty(shape)
+        emsg = 'src y-coordinate points .* do not align'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(data, self.sx_points, self.sx_bounds,
+                self.sy_points, self.sy_bounds,
+                self.sx_dim, self.sy_dim,
+                self.gx_bounds, self.gy_bounds)
+
+    def test_grid_x_bounds_and_y_bounds(self):
+        shape = np.array(self.gy_bounds.shape) + 1
+        gy_bounds = np.empty(shape)
+        emsg = 'Misaligned grid'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(self.data, self.sx_points, self.sx_bounds,
+                self.sy_points, self.sy_bounds,
+                self.sx_dim, self.sy_dim,
+                self.gx_bounds, gy_bounds)
+
+
+class TestRegridSingleLevel(unittest.TestCase):
+    def setUp(self):
+        # Source has points shape (y:6, x:8)
+        self.ny, self.nx = self.shape = (6, 8)
+        size = np.prod(self.shape)
+        self.data = np.arange(size).reshape(self.shape)
+        self.sx_points = np.arange(1, self.nx + 1) - 0.5
+        self.sx_bounds = np.arange(self.nx + 1)
+        self.sy_points = np.arange(1, self.ny + 1) - 0.5
+        self.sy_bounds = np.arange(self.ny + 1)
+        self.sy_dim, self.sx_dim = 0, 1
+        # Target grid has points shape (y:2, x:2)
+        gx_bounds = np.array([1.5, 4.0, 6.5], dtype=np.float64)
+        gy_bounds = np.array([1.5, 3.0, 4.5], dtype=np.float64)
+        self.gx_bounds, self.gy_bounds = np.meshgrid(gx_bounds, gy_bounds)
+
+    def _expected(self, transpose=False):
+        data = self.data
+        if transpose:
+            data = self.data.T
+        # Expected raster weights per target grid cell.
+        # This is the (fractional) source cell contribution
+        # to each target cell (out of 255)
+        weights = np.array([[[63, 127, 127],   # top left hand cell (tlhc)
+                             [127, 255, 255]],
+                            [[127, 127, 63],   # top right hand cell (trhc)
+                             [255, 255, 127]],
+                            [[127, 255, 255],  # bottom left hand cell (blhc)
+                             [63, 127, 127]],
+                            [[255, 255, 127],  # bottom right hand cell (brhc)
+                             [127, 127, 63]]], dtype=np.uint8)
+        weights = weights / 255
+        # Expected source points per target grid cell.
+        tmp = data[1:-1, 1:-1]
+        shape = (-1, 2, 3)
+        cells = [tmp[slice(0, 2), slice(0, 3)].reshape(shape),       # tlhc
+                 tmp[slice(0, 2), slice(3, None)].reshape(shape),    # trhc
+                 tmp[slice(2, None), slice(0, 3)].reshape(shape),    # blhc
+                 tmp[slice(2, None), slice(3, None)].reshape(shape)] # brhc
+        cells = ma.vstack(cells)
+        # Expected fractional weighted result.
+        num = (cells * weights).sum(axis=(1, 2))
+        dom = weights.sum(axis=(1, 2))
+        expected = num / dom
+        expected = ma.asarray(expected.reshape(2, 2))
+        if transpose:
+            expected = expected.T
+        return expected
+
+    def test_regrid_ok(self):
+        result = agg(self.data, self.sx_points, self.sx_bounds,
+                     self.sy_points, self.sy_bounds,
+                     self.sx_dim, self.sy_dim,
+                     self.gx_bounds, self.gy_bounds)
+        assert_array_equal(result, self._expected())
+
+    def test_regrid_ok_transpose(self):
+        self.data = self.data.T
+        sy_dim, sx_dim = self.sx_dim, self.sy_dim
+        result = agg(self.data, self.sx_points, self.sx_bounds,
+                     self.sy_points, self.sy_bounds,
+                     sx_dim, sy_dim,
+                     self.gx_bounds, self.gy_bounds)
+        expected = self._expected(transpose=True)
+        assert_array_equal(result, expected)
+
+    def test_regrid_ok_src_masked(self):
+        self.data = ma.asarray(self.data)
+        self.data[2, 3] = ma.masked # tlhc 1x masked of 6x src cells
+        self.data[2, 4] = ma.masked # trhc 2x masked of 6x src cells
+        self.data[2, 5] = ma.masked
+        self.data[3, 2] = ma.masked # blhc 3x masked of 6x src cells
+        self.data[3, 3] = ma.masked
+        self.data[4, 3] = ma.masked
+        self.data[3, 4] = ma.masked # brhc 4x masked of 6x src cells
+        self.data[3, 5] = ma.masked
+        self.data[4, 4] = ma.masked
+        self.data[4, 5] = ma.masked
+        result = agg(self.data, self.sx_points, self.sx_bounds,
+                     self.sy_points, self.sy_bounds,
+                     self.sx_dim, self.sy_dim,
+                     self.gx_bounds, self.gy_bounds)
+        assert_array_equal(result, self._expected())
+
+    def test_regrid_ok_src_x_points_cast(self):
+        self.sx_points = np.asarray(self.sx_points, dtype=np.float32)
+        result = agg(self.data, self.sx_points, self.sx_bounds,
+                     self.sy_points, self.sy_bounds,
+                     self.sx_dim, self.sy_dim,
+                     self.gx_bounds, self.gy_bounds)
+        assert_array_equal(result, self._expected())
+
+    def test_regrid_ok_src_y_points_cast(self):
+        self.sy_points = np.asarray(self.sy_points, dtype=np.float32)
+        result = agg(self.data, self.sx_points, self.sx_bounds,
+                     self.sy_points, self.sy_bounds,
+                     self.sx_dim, self.sy_dim,
+                     self.gx_bounds, self.gy_bounds)
+        assert_array_equal(result, self._expected())
+
+    def test_regrid_ok_negative_sx_dim(self):
+        self.sx_dim = -(self.data.ndim - self.sx_dim)
+        result = agg(self.data, self.sx_points, self.sx_bounds,
+                     self.sy_points, self.sy_bounds,
+                     self.sx_dim, self.sy_dim,
+                     self.gx_bounds, self.gy_bounds)
+        assert_array_equal(result, self._expected())
+
+    def test_regrid_ok_negative_sy_dim(self):
+        self.sy_dim = -(self.data.ndim - self.sy_dim)
+        result = agg(self.data, self.sx_points, self.sx_bounds,
+                     self.sy_points, self.sy_bounds,
+                     self.sx_dim, self.sy_dim,
+                     self.gx_bounds, self.gy_bounds)
+        assert_array_equal(result, self._expected())
+
+    def test_regrid_ok_grid_tlhc_out_of_bounds(self):
+        self.gx_bounds[0, 0] = self.gx_bounds[0, 0] * -1
+        result = agg(self.data, self.sx_points, self.sx_bounds,
+                     self.sy_points, self.sy_bounds,
+                     self.sx_dim, self.sy_dim,
+                     self.gx_bounds, self.gy_bounds)
+        expected = self._expected()
+        expected[0, 0] = ma.masked
+        assert_array_equal(result, self._expected())
+
+    def test_regrid_ok_grid_trhc_out_of_bounds(self):
+        self.gx_bounds[0, -1] = self.gx_bounds[0, -1] * 2
+        result = agg(self.data, self.sx_points, self.sx_bounds,
+                     self.sy_points, self.sy_bounds,
+                     self.sx_dim, self.sy_dim,
+                     self.gx_bounds, self.gy_bounds)
+        expected = self._expected()
+        expected[0, 1] = ma.masked
+        assert_array_equal(result, self._expected())
+
+    def test_regrid_ok_grid_blhc_out_of_bounds(self):
+        self.gy_bounds[-1, 0] = self.gy_bounds[-1, 0] * 2
+        result = agg(self.data, self.sx_points, self.sx_bounds,
+                     self.sy_points, self.sy_bounds,
+                     self.sx_dim, self.sy_dim,
+                     self.gx_bounds, self.gy_bounds)
+        expected = self._expected()
+        expected[1, 0] = ma.masked
+        assert_array_equal(result, self._expected())
+
+    def test_regrid_ok_grid_brhc_out_of_bounds(self):
+        self.gy_bounds[-1, -1] = self.gy_bounds[-1, -1] * 2
+        result = agg(self.data, self.sx_points, self.sx_bounds,
+                     self.sy_points, self.sy_bounds,
+                     self.sx_dim, self.sy_dim,
+                     self.gx_bounds, self.gy_bounds)
+        expected = self._expected()
+        expected[1, 1] = ma.masked
+        assert_array_equal(result, self._expected())
+
+    def test_regrid_irregular_src_x_points(self):
+        self.sx_points[-1] = self.sx_points[-1] * 1.1
+        emsg = 'Expected src x-coordinate points to be regular'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(self.data, self.sx_points, self.sx_bounds,
+                self.sy_points, self.sy_bounds,
+                self.sx_dim, self.sy_dim,
+                self.gx_bounds, self.gy_bounds)
+
+    def test_regrid_irregular_src_y_points(self):
+        self.sy_points[0] = self.sy_points[0] * 1.01
+        emsg = 'Expected src y-coordinate points to be regular'
+        with self.assertRaisesRegexp(ValueError, emsg):
+            agg(self.data, self.sx_points, self.sx_bounds,
+                self.sy_points, self.sy_bounds,
+                self.sx_dim, self.sy_dim,
+                self.gx_bounds, self.gy_bounds)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/agg_regrid/tests/test_raster.py
+++ b/lib/agg_regrid/tests/test_raster.py
@@ -1,0 +1,177 @@
+# (C) British Crown Copyright 2015, Met Office
+#
+# This file is part of iris-extras.
+#
+# iris-extras is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# iris-extras is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with iris-extras.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for the `agg_regrid._agg.raster` function."""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, xrange, zip)
+
+import numpy as np
+from numpy.testing import assert_array_equal
+import unittest
+
+from agg_regrid._agg import raster
+
+
+class TestDataType(unittest.TestCase):
+    def setUp(self):
+        self.emsg = 'Buffer dtype mismatch'
+        self.xi = np.arange(4, dtype=np.float64).reshape(2, 2)
+        self.yi = np.arange(4, dtype=np.float64).reshape(2, 2)
+        ny, nx = 10, 8
+        self.weights = np.zeros((ny, nx), dtype=np.uint8)
+
+    def test_weights_bad_dtype(self):
+        weights = np.zeros((5, 5))
+        with self.assertRaisesRegexp(ValueError, self.emsg):
+            raster(weights, self.xi, self.yi)
+
+    def test_xi_bad_dtype(self):
+        xi = np.arange(4).reshape(2, 2)
+        with self.assertRaisesRegexp(ValueError, self.emsg):
+            raster(self.weights, xi, self.yi)
+
+    def test_yi_bad_dtype(self):
+        yi = np.arange(4).reshape(2, 2)
+        with self.assertRaisesRegexp(ValueError, self.emsg):
+            raster(self.weights, self.xi, yi)
+
+
+class TestShape(unittest.TestCase):
+    def setUp(self):
+        self.emsg = 'Buffer has wrong number of dimensions'
+        self.xi = np.arange(4, dtype=np.float64).reshape(2, 2)
+        self.yi = np.arange(4, dtype=np.float64).reshape(2, 2)
+        ny, nx = 10, 8
+        self.weights = np.zeros((ny, nx), dtype=np.uint8)
+
+    def test_weights_bad_shape(self):
+        weights = self.weights.flatten()
+        with self.assertRaisesRegexp(ValueError, self.emsg):
+            raster(weights, self.xi, self.yi)
+
+    def test_xi_bad_shape(self):
+        xi = self.xi.flatten()
+        with self.assertRaisesRegexp(ValueError, self.emsg):
+            raster(self.weights, xi, self.yi)
+
+    def test_yi_bad_shape(self):
+        yi = self.yi.flatten()
+        with self.assertRaisesRegexp(ValueError, self.emsg):
+            raster(self.weights, self.xi, yi)
+
+
+class TestWeightsCoverage(unittest.TestCase):
+    def setUp(self):
+        self.ny, self.nx = self.shape = 6, 8
+        self.weights = np.zeros(self.shape, dtype=np.uint8)
+
+    def test_top_left_cell(self):
+        xi = np.array([[0, 1],
+                       [0, 1]], dtype=np.float64)
+        yi = np.array([[0, 0],
+                       [1, 1]], dtype=np.float64)
+        raster(self.weights, xi, yi)
+        self.assertEqual(self.weights.sum(), 255)
+        self.assertEqual(self.weights[0, 0], 255)
+
+    def test_top_right_cell(self):
+        xi = np.array([[self.nx - 1, self.nx],
+                       [self.nx - 1, self.nx]], dtype=np.float64)
+        yi = np.array([[0, 0],
+                       [1, 1]], dtype=np.float64)
+        raster(self.weights, xi, yi)
+        self.assertEqual(self.weights.sum(), 255)
+        self.assertEqual(self.weights[0, self.nx - 1], 255)
+
+    def test_bottom_left_cell(self):
+        xi = np.array([[0, 1],
+                       [0, 1]], dtype=np.float64)
+        yi = np.array([[self.ny - 1, self.ny - 1],
+                       [self.ny, self.ny]], dtype=np.float64)
+        raster(self.weights, xi, yi)
+        self.assertEqual(self.weights.sum(), 255)
+        self.assertEqual(self.weights[self.ny - 1, 0], 255)
+
+    def test_bottom_right_cell(self):
+        xi = np.array([[self.nx - 1, self.nx],
+                       [self.nx - 1, self.nx]], dtype=np.float64)
+        yi = np.array([[self.ny - 1, self.ny - 1],
+                       [self.ny, self.ny]], dtype=np.float64)
+        raster(self.weights, xi, yi)
+        self.assertEqual(self.weights.sum(), 255)
+        self.assertEqual(self.weights[self.ny - 1, self.nx - 1], 255)
+
+    def test_full_coverage(self):
+        xi = np.array([[0, self.nx],
+                       [0, self.nx]], dtype=np.float64)
+        yi = np.array([[0, 0],
+                       [self.ny, self.ny]], dtype=np.float64)
+        raster(self.weights, xi, yi)
+        expected = np.ones((self.ny, self.nx), dtype=np.float64) * 255
+        assert_array_equal(self.weights, expected)
+
+    def test_inset_by_one_cell(self):
+        xi = np.array([[1, self.nx - 1],
+                       [1, self.nx - 1]], dtype=np.float64)
+        yi = np.array([[1, 1],
+                       [self.ny - 1, self.ny - 1]], dtype=np.float64)
+        raster(self.weights, xi, yi)
+        expected = np.ones((self.ny, self.nx), dtype=np.float64) * 255
+        expected[0, :] = expected[-1, :] = 0
+        expected[:, 0] = expected[:, -1] = 0
+        assert_array_equal(self.weights, expected)
+
+    def test_inset_by_half_cell(self):
+        xi = np.array([[0.5, self.nx - 0.5],
+                       [0.5, self.nx - 0.5]], dtype=np.float64)
+        yi = np.array([[0.5, 0.5],
+                       [self.ny - 0.5, self.ny - 0.5]], dtype=np.float64)
+        raster(self.weights, xi, yi)
+        expected = np.ones((self.ny, self.nx), dtype=np.float64) * 255
+        half, quarter = 255 // 2, 255 // 4
+        expected[0, :] = expected[-1, :] = half
+        expected[:, 0] = expected[:, -1] = half
+        expected[0, 0] = expected[0, -1] = quarter
+        expected[-1, 0] = expected[-1, -1] = quarter
+        assert_array_equal(self.weights, expected)
+
+    def test_rotated(self):
+        xi = np.array([[1.5, 4.5],
+                       [3.5, 6.5]], dtype=np.float64)
+        yi = np.array([[3.5, 0.5],
+                       [5.5, 2.5]], dtype=np.float64)
+        raster(self.weights, xi, yi)
+        expected = np.zeros((self.shape), dtype=np.uint8)
+        full, half, quarter = 255, 255 // 2, 255 // 4
+        # corners ...
+        expected[3, 1] = expected[0, 4] = quarter
+        expected[5, 3] = expected[2, 6] = quarter
+        # edges ...
+        expected[2, 2] = expected[1, 3] = half
+        expected[4, 2] = half
+        expected[1, 5] = half
+        expected[4, 4] = expected[3, 5] = half
+        # inner ...
+        expected[1, 4] = full
+        expected[2, 3] = expected[2, 4] = expected[2, 5] = full
+        expected[3, 2] = expected[3, 3] = expected[3, 4] = full
+        expected[4, 3] = full
+        assert_array_equal(self.weights, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,102 @@
+from __future__ import absolute_import, division, print_function
+
+from distutils.core import setup, Command
+import os
+
+import numpy as np
+import setuptools
+
+
+try:
+    from Cython.Distutils import build_ext
+except ImportError:
+    emsg = 'Cython v0.22+ is required'
+    raise ImportError(emsg)
+
+
+def file_walk_relative(top, remove=''):
+    """
+    Returns a generator of files from the top of the tree, removing
+    the given prefix from the root/file result.
+    """
+    top = top.replace('/', os.path.sep)
+    remove = remove.replace('/', os.path.sep)
+    for root, dirs, fnames in os.walk(top):
+        for fname in fnames:
+            yield os.path.join(root, fname).replace(remove, '')
+
+
+class CleanSource(Command):
+    """
+    Removes orphaned pyc/pyo files from the sources.
+
+    """
+    description = 'clean orphaned pyc/pyo files from sources'
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        for root_path, dir_names, file_names in os.walk('lib'):
+            for file_name in file_names:
+                if file_name.endswith('pyc') or file_name.endswith('pyo'):
+                    compiled_path = os.path.join(root_path, file_name)
+                    source_path = compiled_path[:-1]
+                    if not os.path.exists(source_path):
+                        print('Cleaning', compiled_path)
+                        os.remove(compiled_path)
+
+
+def extract_version():
+    version = None
+    dname = os.path.dirname(__file__)
+    fname = os.path.join(dname, 'lib', 'agg_regrid', '__init__.py')
+    with open(fname, 'r') as fi:
+        for line in fi:
+            if (line.startswith('__version__')):
+                _, version = line.split('=')
+                version = version.strip()[1:-1]  # Remove quotation characters
+                break
+    return version
+
+
+setup(
+    name='iris-extras',
+    version=extract_version(),
+    author='UK Met Office',
+    packages=['agg_regrid', 'agg_regrid.tests'],
+    package_dir={'': 'lib'},
+    ext_modules=[
+        setuptools.Extension(
+            'agg_regrid._agg',
+            [os.path.join('lib', 'agg_regrid', '_agg.pyx'),
+             os.path.join('lib', 'agg_regrid', '_agg_raster.cpp')],
+            include_dirs=[os.path.join('lib', 'agg_regrid'),
+                          np.get_include()],
+            language='c++',
+            ),
+        ],
+    cmdclass={'clean_source': CleanSource, 'build_ext': build_ext},
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        ('License :: OSI Approved :: '
+         'GNU Lesser General Public License v3 or later (LGPLv3+)'),
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: POSIX',
+        'Operating System :: POSIX :: AIX',
+        'Operating System :: POSIX :: Linux',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Scientific/Engineering :: GIS',
+        ],
+    )
+


### PR DESCRIPTION
This PR contains an experimental conservative area-weighted regridder, which uses the Anti-Grain Geometry ([AGG](http://www.antigrain.com/)) to rasterise the conversion of a source cube to a target grid.

This proof-of-concept approach is based on the outstanding [proof-of-proof-of-concept work](https://github.com/rhattersley/iris/tree/agg-regrid) by @rhattersley (bravo :clap:, very clever chap!)

This PR contains the basic core functionality for this novel approach to area-weighted regridding. It's the first step and further development is required to provide a robust capability.

Note that, there is a dependency to link against the agg library e.g.

```
Linux> python setup.py build_ext --inplace -I/path/to/agg/include
```